### PR TITLE
refactor(index): use `\d` over number range character class in regex

### DIFF
--- a/index.js
+++ b/index.js
@@ -31,7 +31,7 @@ const ipaddr = require('ipaddr.js')
  * @private
  */
 
-const DIGIT_REGEXP = /^[0-9]+$/
+const DIGIT_REGEXP = /^\d+$/u
 const isip = ipaddr.isValid
 const parseip = ipaddr.parse
 

--- a/test/all.js
+++ b/test/all.js
@@ -4,7 +4,7 @@ const { test } = require('tap')
 const proxyaddr = require('..')
 
 test('argument req should be required', function (t) {
-  t.throws(proxyaddr.all, /req.*required/)
+  t.throws(proxyaddr.all, /req.*required/u)
   t.end()
 })
 

--- a/test/base.js
+++ b/test/base.js
@@ -4,13 +4,13 @@ const { test } = require('tap')
 const proxyaddr = require('..')
 
 test('req should be required', function (t) {
-  t.throws(proxyaddr, /req.*required/)
+  t.throws(proxyaddr, /req.*required/u)
   t.end()
 })
 
 test('trust should be required', function (t) {
   const req = createReq('127.0.0.1')
-  t.throws(proxyaddr.bind(null, req), /trust.*required/)
+  t.throws(proxyaddr.bind(null, req), /trust.*required/u)
   t.end()
 })
 
@@ -34,7 +34,7 @@ test('trust should accept a string', function (t) {
 
 test('trust should reject a number', function (t) {
   const req = createReq('127.0.0.1')
-  t.throws(proxyaddr.bind(null, req, 42), /unsupported trust argument/)
+  t.throws(proxyaddr.bind(null, req, 42), /unsupported trust argument/u)
   t.end()
 })
 
@@ -78,30 +78,30 @@ test('trust should not alter input array', function (t) {
 
 test('trust should reject non-IP', function (t) {
   const req = createReq('127.0.0.1')
-  t.throws(proxyaddr.bind(null, req, 'blargh'), /invalid IP address/)
-  t.throws(proxyaddr.bind(null, req, '10.0.300.1'), /invalid IP address/)
-  t.throws(proxyaddr.bind(null, req, '::ffff:30.168.1.9000'), /invalid IP address/)
-  t.throws(proxyaddr.bind(null, req, '-1'), /invalid IP address/)
+  t.throws(proxyaddr.bind(null, req, 'blargh'), /invalid IP address/u)
+  t.throws(proxyaddr.bind(null, req, '10.0.300.1'), /invalid IP address/u)
+  t.throws(proxyaddr.bind(null, req, '::ffff:30.168.1.9000'), /invalid IP address/u)
+  t.throws(proxyaddr.bind(null, req, '-1'), /invalid IP address/u)
   t.end()
 })
 
 test('trust should reject bad CIDR', function (t) {
   const req = createReq('127.0.0.1')
-  t.throws(proxyaddr.bind(null, req, '10.0.0.1/internet'), /invalid range on address/)
-  t.throws(proxyaddr.bind(null, req, '10.0.0.1/6000'), /invalid range on address/)
-  t.throws(proxyaddr.bind(null, req, '::1/6000'), /invalid range on address/)
-  t.throws(proxyaddr.bind(null, req, '::ffff:a00:2/136'), /invalid range on address/)
-  t.throws(proxyaddr.bind(null, req, '::ffff:a00:2/-1'), /invalid range on address/)
+  t.throws(proxyaddr.bind(null, req, '10.0.0.1/internet'), /invalid range on address/u)
+  t.throws(proxyaddr.bind(null, req, '10.0.0.1/6000'), /invalid range on address/u)
+  t.throws(proxyaddr.bind(null, req, '::1/6000'), /invalid range on address/u)
+  t.throws(proxyaddr.bind(null, req, '::ffff:a00:2/136'), /invalid range on address/u)
+  t.throws(proxyaddr.bind(null, req, '::ffff:a00:2/-1'), /invalid range on address/u)
   t.end()
 })
 
 test('trust should reject bad netmask', function (t) {
   const req = createReq('127.0.0.1')
-  t.throws(proxyaddr.bind(null, req, '10.0.0.1/255.0.255.0'), /invalid range on address/)
-  t.throws(proxyaddr.bind(null, req, '10.0.0.1/ffc0::'), /invalid range on address/)
-  t.throws(proxyaddr.bind(null, req, 'fe80::/ffc0::'), /invalid range on address/)
-  t.throws(proxyaddr.bind(null, req, 'fe80::/255.255.255.0'), /invalid range on address/)
-  t.throws(proxyaddr.bind(null, req, '::ffff:a00:2/255.255.255.0'), /invalid range on address/)
+  t.throws(proxyaddr.bind(null, req, '10.0.0.1/255.0.255.0'), /invalid range on address/u)
+  t.throws(proxyaddr.bind(null, req, '10.0.0.1/ffc0::'), /invalid range on address/u)
+  t.throws(proxyaddr.bind(null, req, 'fe80::/ffc0::'), /invalid range on address/u)
+  t.throws(proxyaddr.bind(null, req, 'fe80::/255.255.255.0'), /invalid range on address/u)
+  t.throws(proxyaddr.bind(null, req, '::ffff:a00:2/255.255.255.0'), /invalid range on address/u)
   t.end()
 })
 
@@ -414,4 +414,4 @@ function createReq (socketAddr, headers) {
 
 function all () { return true }
 function none () { return false }
-function trust10x (addr) { return /^10\./.test(addr) }
+function trust10x (addr) { return /^10\./u.test(addr) }

--- a/test/compile.js
+++ b/test/compile.js
@@ -4,7 +4,7 @@ const { test } = require('tap')
 const proxyaddr = require('..')
 
 test('trust arg should be required', function (t) {
-  t.throws(proxyaddr.compile, /argument.*required/)
+  t.throws(proxyaddr.compile, /argument.*required/u)
   t.end()
 })
 
@@ -19,7 +19,7 @@ test('trust arg should accept a string', function (t) {
 })
 
 test('trust arg should reject a number', function (t) {
-  t.throws(proxyaddr.compile.bind(null, 42), /unsupported trust argument/)
+  t.throws(proxyaddr.compile.bind(null, 42), /unsupported trust argument/u)
   t.end()
 })
 
@@ -49,16 +49,16 @@ test('trust arg should accept pre-defined names in array', function (t) {
 })
 
 test('trust arg should reject non-IP', function (t) {
-  t.throws(proxyaddr.compile.bind(null, 'blargh'), /invalid IP address/)
-  t.throws(proxyaddr.compile.bind(null, '-1'), /invalid IP address/)
+  t.throws(proxyaddr.compile.bind(null, 'blargh'), /invalid IP address/u)
+  t.throws(proxyaddr.compile.bind(null, '-1'), /invalid IP address/u)
   t.end()
 })
 
 test('trust arg should reject bad CIDR', function (t) {
-  t.throws(proxyaddr.compile.bind(null, '10.0.0.1/6000'), /invalid range on address/)
-  t.throws(proxyaddr.compile.bind(null, '::1/6000'), /invalid range on address/)
-  t.throws(proxyaddr.compile.bind(null, '::ffff:a00:2/136'), /invalid range on address/)
-  t.throws(proxyaddr.compile.bind(null, '::ffff:a00:2/-46'), /invalid range on address/)
+  t.throws(proxyaddr.compile.bind(null, '10.0.0.1/6000'), /invalid range on address/u)
+  t.throws(proxyaddr.compile.bind(null, '::1/6000'), /invalid range on address/u)
+  t.throws(proxyaddr.compile.bind(null, '::ffff:a00:2/136'), /invalid range on address/u)
+  t.throws(proxyaddr.compile.bind(null, '::ffff:a00:2/-46'), /invalid range on address/u)
   t.end()
 })
 


### PR DESCRIPTION
Same thing, and saves a few bytes.
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
