### PR TITLE
types: use `node:` prefix for builtins

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="node" />
 
-import { IncomingMessage } from 'http'
+import { IncomingMessage } from 'node:http'
 
 type FastifyProxyAddr = typeof proxyaddr
 

--- a/types/index.test-d.ts
+++ b/types/index.test-d.ts
@@ -1,5 +1,5 @@
 import proxyaddr from '..'
-import { createServer } from 'http'
+import { createServer } from 'node:http'
 import { expectType } from 'tsd'
 
 createServer(req => {


### PR DESCRIPTION
See https://github.com/fastify/fastify/pull/5896. This is a batch PR, so may have some issues. Please review changes.