### PR TITLE
build(deps-dev): add eslint, peer dep of neostandard

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "beautify-benchmark": "0.2.4",
     "benchmark": "2.1.4",
     "c8": "^10.1.2",
+    "eslint": "^9.17.0",
     "neostandard": "^0.12.0",
     "tape": "^5.7.5",
     "tsd": "^0.31.0"


### PR DESCRIPTION
Missing peer dep. This is a batch PR, so may have some issues. Please review changes.