### PR TITLE
perf: reduce string comparisons

### DIFF
--- a/index.js
+++ b/index.js
@@ -270,14 +270,16 @@ function trustMulti (subnets) {
       let trusted = ip
 
       if (kind !== subnetkind) {
-        if (subnetkind === 'ipv4' && !ip.isIPv4MappedAddress()) {
+        const subnetisipv4 = subnetkind === 'ipv4'
+
+        if (subnetisipv4 && !ip.isIPv4MappedAddress()) {
           // Incompatible IP addresses
           continue
         }
 
         if (!ipconv) {
           // Convert IP to match subnet IP kind
-          ipconv = subnetkind === 'ipv4'
+          ipconv = subnetisipv4
             ? ip.toIPv4Address()
             : ip.toIPv4MappedAddress()
         }


### PR DESCRIPTION
Just a small change that prevents repeated string comparisons in some cases

new:

```sh
trust multiple x  1,450,582 ops/sec ±1.42% (195 runs sampled)
```

old:

```sh
trust multiple x  1,441,307 ops/sec ±1.34% (197 runs sampled)
```